### PR TITLE
fix: fix faker not using configured locale

### DIFF
--- a/src/HttpFixture.php
+++ b/src/HttpFixture.php
@@ -22,7 +22,7 @@ class HttpFixture
 
     public function __construct(array $overrides = [])
     {
-        $this->faker = Factory::create();
+        $this->faker = app(Generator::class);
         $this->overrides = $overrides;
     }
 


### PR DESCRIPTION
Gets the faker generator from the container instead of instantiating a new one. This will then use the user defined configuration for generating fake data.

Fixes: Gromatics/httpfixtures#1